### PR TITLE
Make variable values verbatim

### DIFF
--- a/Generator/DotEnvSourceGenerator.cs
+++ b/Generator/DotEnvSourceGenerator.cs
@@ -31,7 +31,7 @@ public class DotEnvSourceGenerator : ISourceGenerator
             builder.AppendLine("namespace DotEnv.Generated");
             builder.AppendLine("{");
             builder.AppendLine("    /// <summary>");
-            builder.AppendLine($"   /// An auto-generated class which holds constants derived from '{Path.GetFileName(envFile.Path)}'");
+            builder.AppendLine($"    /// An auto-generated class which holds constants derived from '{Path.GetFileName(envFile.Path)}'");
             builder.AppendLine("    /// </summary>");
             builder.AppendLine($"    public static class {className}");
             builder.AppendLine("    {");

--- a/Generator/StringExtensions.cs
+++ b/Generator/StringExtensions.cs
@@ -284,7 +284,7 @@ namespace DotEnvGenerator
             {
                 value = $"{value}\"";
             }
-            return value;
+            return "@" + value;
         }
         public static string[] CommaSplit(this string value)
         {


### PR DESCRIPTION
Put '@' in front of string literals since a lot of environment variables contain backslashes that trigger "unrecognized escape sequence" build errors.