### PR TITLE
Fix build by adding missing `DotEnvGenerator.props`

### DIFF
--- a/Generator/build/DotEnvGenerator.props
+++ b/Generator/build/DotEnvGenerator.props
@@ -1,0 +1,6 @@
+﻿<Project>
+  <ItemGroup>
+      <CompilerVisibleProperty Include="DotEnv_EnableLogging" />
+      <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="EnableLogging" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR fixes issue #2 by adding the missing `DotEnvGenerator.props` file. The file was recovered from the latest version of the [**DotEnvGenerator**](https://www.nuget.org/packages/DotEnvGenerator/0.1.0) package.

I think it might have been ignored so far due to the following rule in `.gitignore` so needed a _forced add_ (`git add -f`):

https://github.com/RainwayApp/dot-env-generator/blob/3355f0701c623fe345f7476268c29f62d0a084e9/.gitignore#L27
